### PR TITLE
Implement HMAC calculation in CloudFront function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# hmac
+# HMAC CloudFront Function
+
+This project deploys an AWS CloudFront Function that calculates an HMAC
+using `SHA-256`. The key and data values are provided via the `key` and
+`data` query string parameters. Both values must be URL safe base64
+encoded and no longer than 128 bytes when decoded.
+
+The response body contains the HMAC value, encoded as URL safe base64.

--- a/function.js
+++ b/function.js
@@ -1,29 +1,57 @@
-function handler(event) {
-  var now = new Date();
-
-  // Precompute each part manually to avoid closure + method calls
-  var year = now.getUTCFullYear();
-  var month = now.getUTCMonth() + 1;
-  var day = now.getUTCDate();
-  var hour = now.getUTCHours();
-  var minute = now.getUTCMinutes();
-  var second = now.getUTCSeconds();
-
-  // Inline padding with arithmetic to avoid string method overhead
-  var pad2 = (n) => (n < 10 ? '0' + n : '' + n);
-
-  var timestamp = `${year}${pad2(month)}${pad2(day)}T${pad2(hour)}${pad2(minute)}${pad2(second)}Z`;
-
+async function handler(event) {
   var response = event.response;
-  response.statusCode = 200;
   response.statusDescription = 'OK';
   response.headers['content-type'] = { value: 'text/plain' };
   response.headers['content-encoding'] = { value: 'identity' };
-  response.headers['x-amz-date'] = { value: timestamp };
-  response.body = {
-    encoding: 'text',
-    data: timestamp,
-  };
 
+  var qs = event.request.querystring || {};
+  if (!qs.key || !qs.data) {
+    response.statusCode = 400;
+    response.body = { encoding: 'text', data: 'missing key or data' };
+    return response;
+  }
+
+  var keyBytes = base64UrlDecode(qs.key.value);
+  var dataBytes = base64UrlDecode(qs.data.value);
+
+  if (keyBytes.length > 128 || dataBytes.length > 128) {
+    response.statusCode = 400;
+    response.body = { encoding: 'text', data: 'parameter too long' };
+    return response;
+  }
+
+  var cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  var sig = new Uint8Array(
+    await crypto.subtle.sign('HMAC', cryptoKey, dataBytes)
+  );
+  var out = base64UrlEncode(sig);
+
+  response.statusCode = 200;
+  response.body = { encoding: 'text', data: out };
   return response;
+}
+
+function base64UrlDecode(str) {
+  str = str.replace(/-/g, '+').replace(/_/g, '/');
+  while (str.length % 4) str += '=';
+  var binary = atob(str);
+  var bytes = new Uint8Array(binary.length);
+  for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function base64UrlEncode(bytes) {
+  var binary = '';
+  for (var i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  var base64 = btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return base64;
 }

--- a/lib/x-amz-hmac-stack.ts
+++ b/lib/x-amz-hmac-stack.ts
@@ -20,8 +20,8 @@ export class XAmzHmacStack extends cdk.Stack {
     });
 
     const cfFunction = new cloudfront.Function(this, 'CloudFrontFunction', {
-      functionName: 'xAmzDateFunction',
-      comment: 'Return current X-Amz-Date string',
+      functionName: 'xAmzHmacFunction',
+      comment: 'Return HMAC via query parameters',
       runtime: cloudfront.FunctionRuntime.JS_2_0,
       code: cloudfront.FunctionCode.fromFile({ filePath: 'function.js' }),
     });


### PR DESCRIPTION
## Summary
- replace timestamp logic with HMAC calculation
- limit key and data params to 128 bytes
- output base64url encoded signature
- document new behaviour in README

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'aws-cdk-lib')*