### PR TITLE
Use Node crypto in cloudfront function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # HMAC CloudFront Function
 
 This project deploys an AWS CloudFront Function that calculates an HMAC
-using `SHA-256`. The key and data values are provided via the `key` and
-`data` query string parameters. Both values must be URL safe base64
-encoded and no longer than 128 bytes when decoded.
+using `SHA-256`. The function leverages CloudFront's `crypto` module to
+compute the signature. The `key` and `data` values are provided via the
+`key` and `data` query string parameters. Both values must be URL safe
+base64 encoded and no longer than 128 bytes when decoded.
 
 The response body contains the HMAC value, encoded as URL safe base64.


### PR DESCRIPTION
## Summary
- implement HMAC using the new CloudFront `crypto` module
- note usage of the crypto module in the README

## Testing
- `npm test` *(fails: Missing script)*