### PR TITLE
Add path-based chained HMAC and SigV4 derivation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
       - run: npm install
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,40 @@
-# HMAC CloudFront Function
+# hmac.sh
 
-This project deploys an AWS CloudFront Function that calculates an HMAC
-using `SHA-256`. The function leverages CloudFront's `crypto` module to
-compute the signature. The `key` and `data` values are provided via the
-`key` and `data` query string parameters. Both values must be URL safe
-base64 encoded and no longer than 128 bytes when decoded.
+`hmac.sh` derives SHA-256 HMACs using positional URL path parameters. The first
+component is a URL-safe, unpadded base64 key; every following component is
+URL-decoded UTF-8 data. No argument labels or query string are needed:
 
-The response body contains the HMAC value, encoded as URL safe base64.
+```text
+https://hmac.sh/{base64url-key}/{data}[/{data}...]
+```
+
+All data components are chained in order: each HMAC digest becomes the key for
+the next component. A successful request responds with `303 See Other` and
+redirects to `/{base64url-digest}`. Append another `/data` component to that URL
+to continue a derivation.
+
+## AWS Signature Version 4
+
+Keep the AWS secret access key off the network by deriving the date key locally:
+
+```js
+const crypto = require('node:crypto');
+const dateKey = crypto
+  .createHmac('sha256', `AWS4${process.env.AWS_SECRET_ACCESS_KEY}`)
+  .update('20260730')
+  .digest('base64url');
+```
+
+Then derive the complete SigV4 signing key in one request:
+
+```text
+https://hmac.sh/{dateKey}/{region}/{service}
+```
+
+The three-component SigV4 shortcut automatically performs the final
+`aws4_request` HMAC step. For example, `/dateKey/us-east-1/s3` chains `us-east-1`,
+`s3`, and `aws4_request`. Only the already-derived date key is sent to the
+service; the AWS secret access key never is.
+
+Path components are limited to 128 characters and keys to 128 decoded bytes.
+Responses include `Cache-Control: no-store`.

--- a/function.js
+++ b/function.js
@@ -2,41 +2,59 @@ var crypto = require('crypto');
 
 async function handler(event) {
   var response = event.response;
-  response.statusDescription = 'OK';
-  response.headers['content-type'] = { value: 'text/plain' };
-  response.headers['content-encoding'] = { value: 'identity' };
+  var parts;
 
-  var qs = event.request.querystring || {};
-  if (!qs.key || !qs.data) {
-    response.statusCode = 400;
-    response.body = { encoding: 'text', data: 'missing key or data' };
-    return response;
+  try {
+    parts = event.request.uri.split('/').filter(Boolean).map(decodeURIComponent);
+  } catch (error) {
+    return fail(response, 'invalid URL encoding');
   }
 
-  var keyBytes = base64UrlDecode(qs.key.value);
-  var dataBytes = base64UrlDecode(qs.data.value);
-
-  if (keyBytes.length > 128 || dataBytes.length > 128) {
-    response.statusCode = 400;
-    response.body = { encoding: 'text', data: 'parameter too long' };
-    return response;
+  if (parts.length < 2) {
+    return fail(response, 'use /{base64url-key}/{data}[/{data}...]');
   }
 
-  var hmac = crypto.createHmac('sha256', keyBytes);
-  hmac.update(dataBytes);
-  var out = hmac.digest('base64url');
+  var key;
+  try {
+    key = base64UrlDecode(parts.shift());
+  } catch (error) {
+    return fail(response, 'invalid base64url key');
+  }
 
-  response.statusCode = 200;
-  response.body = { encoding: 'text', data: out };
+  if (!key.length || key.length > 128 || parts.some(function (part) { return part.length > 128; })) {
+    return fail(response, 'parameter empty or too long');
+  }
+
+  // A date key followed by region and service is the common SigV4 shortcut.
+  // Complete its final, constant derivation step without putting another value in the URL.
+  if (parts.length === 2) parts.push('aws4_request');
+
+  for (var i = 0; i < parts.length; i++) {
+    key = crypto.createHmac('sha256', key).update(parts[i], 'utf8').digest();
+  }
+
+  var digest = key.toString('base64url');
+  response.statusCode = 303;
+  response.statusDescription = 'See Other';
+  response.headers.location = { value: '/' + digest };
+  response.headers['cache-control'] = { value: 'no-store' };
+  response.headers['content-type'] = { value: 'text/plain; charset=utf-8' };
+  response.body = { encoding: 'text', data: digest };
+  return response;
+}
+
+function fail(response, message) {
+  response.statusCode = 400;
+  response.statusDescription = 'Bad Request';
+  response.headers['cache-control'] = { value: 'no-store' };
+  response.headers['content-type'] = { value: 'text/plain; charset=utf-8' };
+  response.body = { encoding: 'text', data: message };
   return response;
 }
 
 function base64UrlDecode(str) {
+  if (!/^[A-Za-z0-9_-]+$/.test(str)) throw new Error('invalid base64url');
   str = str.replace(/-/g, '+').replace(/_/g, '/');
   while (str.length % 4) str += '=';
-  var binary = atob(str);
-  var bytes = new Uint8Array(binary.length);
-  for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
+  return Buffer.from(str, 'base64');
 }
-

--- a/lib/x-amz-hmac-stack.ts
+++ b/lib/x-amz-hmac-stack.ts
@@ -21,7 +21,7 @@ export class XAmzHmacStack extends cdk.Stack {
 
     const cfFunction = new cloudfront.Function(this, 'CloudFrontFunction', {
       functionName: 'xAmzHmacFunction',
-      comment: 'Return HMAC via query parameters',
+      comment: 'Derive chained HMAC values from URL path parameters',
       runtime: cloudfront.FunctionRuntime.JS_2_0,
       code: cloudfront.FunctionCode.fromFile({ filePath: 'function.js' }),
     });

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "aws-cdk-lib": "^2.199.0",
-    "constructs": "^10.2.0",
+    "aws-cdk-lib": "^2.262.2",
+    "constructs": "^10.7.2",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@types/node": "^18.18.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.0"
+    "@types/node": "^24.0.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const context = { Buffer, require };
+vm.runInNewContext(fs.readFileSync('function.js', 'utf8'), context);
+
+async function request(uri) {
+  return context.handler({
+    request: { uri },
+    response: { headers: {} },
+  });
+}
+
+test('redirects a single HMAC to its chainable digest URL', async () => {
+  const key = Buffer.from('secret').toString('base64url');
+  const expected = crypto.createHmac('sha256', 'secret').update('hello').digest('base64url');
+  const response = await request(`/${key}/hello`);
+
+  assert.equal(response.statusCode, 303);
+  assert.equal(response.headers.location.value, `/${expected}`);
+  assert.equal(response.headers['cache-control'].value, 'no-store');
+});
+
+test('derives a complete SigV4 signing key with the shortcut', async () => {
+  let expected = crypto.createHmac('sha256', 'AWS4secret').update('20260730').digest();
+  const dateKey = expected.toString('base64url');
+  for (const value of ['us-east-1', 's3', 'aws4_request']) {
+    expected = crypto.createHmac('sha256', expected).update(value).digest();
+  }
+
+  const response = await request(`/${dateKey}/us-east-1/s3`);
+  assert.equal(response.headers.location.value, `/${expected.toString('base64url')}`);
+});
+
+test('chains arbitrary explicit data components in order', async () => {
+  let expected = Buffer.from('key');
+  for (const value of ['one', 'two', 'three']) {
+    expected = crypto.createHmac('sha256', expected).update(value).digest();
+  }
+
+  const response = await request(`/${Buffer.from('key').toString('base64url')}/one/two/three`);
+  assert.equal(response.headers.location.value, `/${expected.toString('base64url')}`);
+});
+
+test('rejects missing parameters and malformed keys', async () => {
+  assert.equal((await request('/')).statusCode, 400);
+  assert.equal((await request('/not+base64/data')).statusCode, 400);
+});


### PR DESCRIPTION
### Motivation
- Replace labeled query-parameter interface with a simpler slash-delimited URL path to make chaining and composition ergonomic.
- Allow multi-step HMAC chaining so a sequence of path components can be derived in order without round trips.
- Provide a safe SigV4 convenience shortcut that accepts an already-derived date key and completes the `aws4_request` step so the AWS secret never leaves the client.
- Refresh CDK/TypeScript/CI tool versions to stay current with platform runtimes.

### Description
- Rewrote `function.js` to parse `event.request.uri` path components, validate URL-safe base64 keys, enforce size limits, chain HMACs in order, and automatically append `aws4_request` when the SigV4 3-component shortcut is used, then return a `303 See Other` redirect to `/{base64url-digest}` with `Cache-Control: no-store`.
- Updated `README.md` to document the new path-based API, chaining semantics, offline date-key derivation example, and the SigV4 shortcut usage.
- Added unit tests in `test/function.test.js` covering single-step redirect, multi-step chaining, the SigV4 shortcut, and invalid input handling, and wired them to `node --test` execution.
- Bumped dependency versions in `package.json` for `aws-cdk-lib`, `constructs`, `typescript`, `ts-node`, and `@types/node`, and updated GitHub Actions to `actions/setup-node@v4` with `node-version: 24`; also updated CloudFront Function comment in `lib/x-amz-hmac-stack.ts`.

### Testing
- Ran `node --test` and all tests passed (4 tests, 0 failures).
- Ran `npx tsc --noEmit` and TypeScript type-check succeeded with no errors.
- Synthesized the CDK app via `app.synth()` using the installed `aws-cdk-lib` and confirmed a manifest file was produced successfully.
- Ran `git diff --check` with no whitespace or patch issues; note that `npx cdk synth` via `npx` could not be performed in this environment due to registry access (HTTP 403), so synthesis was validated via the installed library instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6aeaed949083308bead9f73c5d5f52)