### PR TITLE
Path-based chained HMAC CloudFront function; add tests and update infra/deps/workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
       - run: npm install
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,44 @@
-# HMAC CloudFront Function
+# hmac.sh
 
-This project deploys an AWS CloudFront Function that calculates an HMAC
-using `SHA-256`. The function leverages CloudFront's `crypto` module to
-compute the signature. The `key` and `data` values are provided via the
-`key` and `data` query string parameters. Both values must be URL safe
-base64 encoded and no longer than 128 bytes when decoded.
+`hmac.sh` derives SHA-256 HMACs using positional URL path parameters. The first
+component is a URL-safe, unpadded base64 key; every following component is
+URL-decoded UTF-8 data. No argument labels or query string are needed:
 
-The response body contains the HMAC value, encoded as URL safe base64.
+```text
+https://hmac.sh/{base64url-key}/{data}[/{data}...]
+```
+
+All data components are chained in order: each HMAC digest becomes the key for
+the next component. A successful request responds with `303 See Other` and
+redirects to `/{base64url-digest}`. Append another `/data` component to that URL
+to continue a derivation. Following the redirect displays the digest with a
+`200 OK` response rather than usage text.
+
+## AWS Signature Version 4
+
+Keep the AWS secret access key off the network by deriving the date key locally:
+
+```js
+const crypto = require('node:crypto');
+const dateKey = crypto
+  .createHmac('sha256', `AWS4${process.env.AWS_SECRET_ACCESS_KEY}`)
+  .update('20260730')
+  .digest('base64url');
+```
+
+Then derive the complete SigV4 signing key in one request:
+
+```text
+https://hmac.sh/{dateKey}/{region}/{service}
+```
+
+The three-component SigV4 shortcut automatically performs the final
+`aws4_request` HMAC step. For example, `/dateKey/us-east-1/s3` chains `us-east-1`,
+`s3`, and `aws4_request`. Only the already-derived date key is sent to the
+service; the AWS secret access key never is.
+
+Path components are limited to 128 characters and keys to 128 decoded bytes.
+Responses include `Cache-Control: no-store`.
+
+The CloudFront Function is attached to the viewer-request event and returns the
+result directly; requests do not reach the configured fallback origin.

--- a/function.js
+++ b/function.js
@@ -1,42 +1,71 @@
 var crypto = require('crypto');
 
 async function handler(event) {
-  var response = event.response;
-  response.statusDescription = 'OK';
-  response.headers['content-type'] = { value: 'text/plain' };
-  response.headers['content-encoding'] = { value: 'identity' };
+  // This function runs at viewer-request time so it can respond directly. A
+  // viewer-response function cannot change the origin response status to the
+  // redirect required by this API.
+  var response = { headers: {} };
+  var parts;
 
-  var qs = event.request.querystring || {};
-  if (!qs.key || !qs.data) {
-    response.statusCode = 400;
-    response.body = { encoding: 'text', data: 'missing key or data' };
-    return response;
+  try {
+    parts = event.request.uri.split('/').filter(Boolean).map(decodeURIComponent);
+  } catch (error) {
+    return fail(response, 'invalid URL encoding');
   }
 
-  var keyBytes = base64UrlDecode(qs.key.value);
-  var dataBytes = base64UrlDecode(qs.data.value);
-
-  if (keyBytes.length > 128 || dataBytes.length > 128) {
-    response.statusCode = 400;
-    response.body = { encoding: 'text', data: 'parameter too long' };
-    return response;
+  if (!parts.length) {
+    return fail(response, 'use /{base64url-key}/{data}[/{data}...]');
   }
 
-  var hmac = crypto.createHmac('sha256', keyBytes);
-  hmac.update(dataBytes);
-  var out = hmac.digest('base64url');
+  var key;
+  try {
+    key = base64UrlDecode(parts.shift());
+  } catch (error) {
+    return fail(response, 'invalid base64url key');
+  }
 
-  response.statusCode = 200;
-  response.body = { encoding: 'text', data: out };
+  if (!key.length || key.length > 128 || parts.some(function (part) { return part.length > 128; })) {
+    return fail(response, 'parameter empty or too long');
+  }
+
+  // Browsers and `curl -L` follow the completion redirect. Render that digest
+  // instead of replacing it with usage advice; another path component can be
+  // appended to the same URL to continue the chain.
+  if (!parts.length) return result(response, key.toString('base64url'), 200);
+
+  // A date key followed by region and service is the common SigV4 shortcut.
+  // Complete its final, constant derivation step without putting another value in the URL.
+  if (parts.length === 2) parts.push('aws4_request');
+
+  for (var i = 0; i < parts.length; i++) {
+    key = crypto.createHmac('sha256', key).update(parts[i], 'utf8').digest();
+  }
+
+  return result(response, key.toString('base64url'), 303);
+}
+
+function result(response, digest, statusCode) {
+  response.statusCode = statusCode;
+  response.statusDescription = statusCode === 303 ? 'See Other' : 'OK';
+  if (statusCode === 303) response.headers.location = { value: '/' + digest };
+  response.headers['cache-control'] = { value: 'no-store' };
+  response.headers['content-type'] = { value: 'text/plain; charset=utf-8' };
+  response.body = { encoding: 'text', data: digest };
+  return response;
+}
+
+function fail(response, message) {
+  response.statusCode = 400;
+  response.statusDescription = 'Bad Request';
+  response.headers['cache-control'] = { value: 'no-store' };
+  response.headers['content-type'] = { value: 'text/plain; charset=utf-8' };
+  response.body = { encoding: 'text', data: message };
   return response;
 }
 
 function base64UrlDecode(str) {
+  if (!/^[A-Za-z0-9_-]+$/.test(str)) throw new Error('invalid base64url');
   str = str.replace(/-/g, '+').replace(/_/g, '/');
   while (str.length % 4) str += '=';
-  var binary = atob(str);
-  var bytes = new Uint8Array(binary.length);
-  for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
+  return Buffer.from(str, 'base64');
 }
-

--- a/lib/x-amz-hmac-stack.ts
+++ b/lib/x-amz-hmac-stack.ts
@@ -21,7 +21,7 @@ export class XAmzHmacStack extends cdk.Stack {
 
     const cfFunction = new cloudfront.Function(this, 'CloudFrontFunction', {
       functionName: 'xAmzHmacFunction',
-      comment: 'Return HMAC via query parameters',
+      comment: 'Derive chained HMAC values from URL path parameters',
       runtime: cloudfront.FunctionRuntime.JS_2_0,
       code: cloudfront.FunctionCode.fromFile({ filePath: 'function.js' }),
     });
@@ -36,7 +36,7 @@ export class XAmzHmacStack extends cdk.Stack {
         functionAssociations: [
           {
             function: cfFunction,
-            eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
           },
         ],
       },

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "aws-cdk-lib": "^2.199.0",
-    "constructs": "^10.2.0",
+    "aws-cdk-lib": "^2.262.2",
+    "constructs": "^10.7.2",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@types/node": "^18.18.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.0"
+    "@types/node": "^24.0.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const context = { Buffer, require };
+vm.runInNewContext(fs.readFileSync('function.js', 'utf8'), context);
+
+async function request(uri) {
+  return context.handler({
+    request: { uri },
+  });
+}
+
+test('does not require an origin response to handle a request', async () => {
+  const key = Buffer.from('secret').toString('base64url');
+  const response = await request(`/${key}/hello`);
+
+  assert.equal(response.statusCode, 303);
+});
+
+test('redirects a single HMAC to its chainable digest URL', async () => {
+  const key = Buffer.from('secret').toString('base64url');
+  const expected = crypto.createHmac('sha256', 'secret').update('hello').digest('base64url');
+  const response = await request(`/${key}/hello`);
+
+  assert.equal(response.statusCode, 303);
+  assert.equal(response.headers.location.value, `/${expected}`);
+  assert.equal(response.headers['cache-control'].value, 'no-store');
+});
+
+test('renders the digest after following the completion redirect', async () => {
+  const digest = crypto.createHmac('sha256', 'secret').update('hello').digest('base64url');
+  const response = await request(`/${digest}`);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.data, digest);
+  assert.equal(response.headers.location, undefined);
+});
+
+test('derives a complete SigV4 signing key with the shortcut', async () => {
+  let expected = crypto.createHmac('sha256', 'AWS4secret').update('20260730').digest();
+  const dateKey = expected.toString('base64url');
+  for (const value of ['us-east-1', 's3', 'aws4_request']) {
+    expected = crypto.createHmac('sha256', expected).update(value).digest();
+  }
+
+  const response = await request(`/${dateKey}/us-east-1/s3`);
+  assert.equal(response.headers.location.value, `/${expected.toString('base64url')}`);
+});
+
+test('chains arbitrary explicit data components in order', async () => {
+  let expected = Buffer.from('key');
+  for (const value of ['one', 'two', 'three']) {
+    expected = crypto.createHmac('sha256', expected).update(value).digest();
+  }
+
+  const response = await request(`/${Buffer.from('key').toString('base64url')}/one/two/three`);
+  assert.equal(response.headers.location.value, `/${expected.toString('base64url')}`);
+});
+
+test('rejects missing parameters and malformed keys', async () => {
+  assert.equal((await request('/')).statusCode, 400);
+  assert.equal((await request('/not+base64/data')).statusCode, 400);
+});


### PR DESCRIPTION
### Motivation

- Replace the previous query-parameter HMAC API with a path-based, chainable derivation API that can derive intermediate HMACs and SigV4 signing keys without exposing the AWS secret. 
- Ensure the CloudFront Function can respond directly at viewer-request time so it can issue the required redirects and short-circuit origin traffic. 
- Modernize build/runtime tooling and CI to current Node and CDK versions.

### Description

- Rewrite `function.js` to parse URL path components, decode a base64url key with `Buffer`, chain HMAC(SHA-256) derivations over successive path components, return `303 See Other` redirects to the digest URL for completion, and render the digest at `200 OK` when requested directly. 
- Add SigV4 shortcut handling so a 2-component path (`dateKey/region/service`) auto-appends `aws4_request` to produce the complete signing key. 
- Add `test/function.test.js` unit tests that exercise redirect behavior, digest rendering, chaining, SigV4 derivation, and malformed input handling. 
- Update CDK stack (`lib/x-amz-hmac-stack.ts`) to attach the CloudFront Function at `VIEWER_REQUEST`, update the function comment, and keep the distribution/configuration consistent with the new behavior. 
- Bump dependencies in `package.json` (`aws-cdk-lib`, `constructs`, `@types/node`, `typescript`) and update GitHub Actions workflow to `actions/setup-node@v4` with `node-version: 24`.

### Testing

- Ran the unit tests in `test/function.test.js` with Node's test runner (via `node test/function.test.js`) and all tests completed successfully. 
- No automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6aeaed949083308bead9f73c5d5f52)