### PR TITLE
Respond at viewer request without Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ https://hmac.sh/{base64url-key}/{data}[/{data}...]
 All data components are chained in order: each HMAC digest becomes the key for
 the next component. A successful request responds with `303 See Other` and
 redirects to `/{base64url-digest}`. Append another `/data` component to that URL
-to continue a derivation.
+to continue a derivation. Following the redirect displays the digest with a
+`200 OK` response rather than usage text.
 
 ## AWS Signature Version 4
 
@@ -38,3 +39,6 @@ service; the AWS secret access key never is.
 
 Path components are limited to 128 characters and keys to 128 decoded bytes.
 Responses include `Cache-Control: no-store`.
+
+The CloudFront Function is attached to the viewer-request event and returns the
+result directly; requests do not reach the configured fallback origin.

--- a/function.js
+++ b/function.js
@@ -1,7 +1,11 @@
 var crypto = require('crypto');
 
 async function handler(event) {
-  var response = event.response;
+  // This function runs at viewer-request time so it can respond directly. A
+  // viewer-response function cannot change the origin response status to the
+  // redirect required by this API, and is skipped entirely when the origin
+  // returns an error for a path it does not serve.
+  var response = { headers: {} };
   var parts;
 
   try {
@@ -10,13 +14,14 @@ async function handler(event) {
     return fail(response, 'invalid URL encoding');
   }
 
-  if (parts.length < 2) {
+  if (!parts.length) {
     return fail(response, 'use /{base64url-key}/{data}[/{data}...]');
   }
 
+  var encodedKey = parts.shift();
   var key;
   try {
-    key = base64UrlDecode(parts.shift());
+    key = base64UrlDecode(encodedKey);
   } catch (error) {
     return fail(response, 'invalid base64url key');
   }
@@ -25,18 +30,32 @@ async function handler(event) {
     return fail(response, 'parameter empty or too long');
   }
 
+  // Browsers and `curl -L` follow the completion redirect. Render that digest
+  // instead of replacing it with usage advice; another path component can be
+  // appended to the same URL to continue the chain.
+  if (!parts.length) return result(response, encodedKey, 200);
+
   // A date key followed by region and service is the common SigV4 shortcut.
   // Complete its final, constant derivation step without putting another value in the URL.
   if (parts.length === 2) parts.push('aws4_request');
 
+  var digest;
   for (var i = 0; i < parts.length; i++) {
-    key = crypto.createHmac('sha256', key).update(parts[i], 'utf8').digest();
+    var hmac = crypto.createHmac('sha256', key);
+    hmac.update(parts[i]);
+    // The runtime has no Buffer: take the digest as base64url text and decode
+    // it back to bytes to key the next round.
+    digest = hmac.digest('base64url');
+    key = base64UrlDecode(digest);
   }
 
-  var digest = key.toString('base64url');
-  response.statusCode = 303;
-  response.statusDescription = 'See Other';
-  response.headers.location = { value: '/' + digest };
+  return result(response, digest, 303);
+}
+
+function result(response, digest, statusCode) {
+  response.statusCode = statusCode;
+  response.statusDescription = statusCode === 303 ? 'See Other' : 'OK';
+  if (statusCode === 303) response.headers.location = { value: '/' + digest };
   response.headers['cache-control'] = { value: 'no-store' };
   response.headers['content-type'] = { value: 'text/plain; charset=utf-8' };
   response.body = { encoding: 'text', data: digest };
@@ -56,5 +75,8 @@ function base64UrlDecode(str) {
   if (!/^[A-Za-z0-9_-]+$/.test(str)) throw new Error('invalid base64url');
   str = str.replace(/-/g, '+').replace(/_/g, '/');
   while (str.length % 4) str += '=';
-  return Buffer.from(str, 'base64');
+  var binary = atob(str);
+  var bytes = new Uint8Array(binary.length);
+  for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
 }

--- a/lib/x-amz-hmac-stack.ts
+++ b/lib/x-amz-hmac-stack.ts
@@ -36,7 +36,7 @@ export class XAmzHmacStack extends cdk.Stack {
         functionAssociations: [
           {
             function: cfFunction,
-            eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
           },
         ],
       },

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -4,15 +4,29 @@ const fs = require('node:fs');
 const test = require('node:test');
 const vm = require('node:vm');
 
-const context = { Buffer, require };
+// Mirror the CloudFront Functions runtime 2.0 surface: crypto and atob are
+// available, Buffer and the rest of the Node.js standard library are not.
+const context = {
+  atob: (data) => Buffer.from(data, 'base64').toString('binary'),
+  require: (id) => {
+    assert.equal(id, 'crypto');
+    return crypto;
+  },
+};
 vm.runInNewContext(fs.readFileSync('function.js', 'utf8'), context);
 
 async function request(uri) {
   return context.handler({
     request: { uri },
-    response: { headers: {} },
   });
 }
+
+test('does not require an origin response to handle a request', async () => {
+  const key = Buffer.from('secret').toString('base64url');
+  const response = await request(`/${key}/hello`);
+
+  assert.equal(response.statusCode, 303);
+});
 
 test('redirects a single HMAC to its chainable digest URL', async () => {
   const key = Buffer.from('secret').toString('base64url');
@@ -22,6 +36,15 @@ test('redirects a single HMAC to its chainable digest URL', async () => {
   assert.equal(response.statusCode, 303);
   assert.equal(response.headers.location.value, `/${expected}`);
   assert.equal(response.headers['cache-control'].value, 'no-store');
+});
+
+test('renders the digest after following the completion redirect', async () => {
+  const digest = crypto.createHmac('sha256', 'secret').update('hello').digest('base64url');
+  const response = await request(`/${digest}`);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.data, digest);
+  assert.equal(response.headers.location, undefined);
 });
 
 test('derives a complete SigV4 signing key with the shortcut', async () => {


### PR DESCRIPTION
### Motivation

hmac.sh has been broken since #3 deployed: the path-based API left the function at viewer-response, but CloudFront skips viewer-response functions when the origin errors — and the example.com origin 404s every path except `/`. Every derivation request returns the origin's 404 page. Separately, #3 introduced `Buffer`, which the CloudFront Functions JS 2.0 runtime does not provide, so the function would throw on every request even when invoked.

### Description

- Move the function association to `VIEWER_REQUEST` and build the response in the function, so requests never depend on the origin.
- Render the digest with `200 OK` when a single-component path is requested, so browsers and `curl -L` following the completion redirect see the digest rather than usage text.
- Replace `Buffer` with the `atob`/`Uint8Array` decoding the pre-#3 function used in production. Chaining takes each digest as base64url text and decodes it back to bytes for the next round.
- Run the tests in a VM context that mirrors the runtime — no `Buffer`, `require` restricted to `crypto` — so runtime-incompatible code fails the suite. Add coverage for origin-independent handling and digest rendering.

Supersedes #4, which carried the same viewer-request fix but was based on the pre-#3 main (merge conflict) and retained the `Buffer` dependency its review flagged.

### Testing

- `node --test test/function.test.js` — 6 tests pass.
- `cdk synth` succeeds with a current CLI (≥ 2.1133.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CMLaRdrMARs8CJLpdw4Mm